### PR TITLE
Add match timer and penalty shootout logic

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,38 +5,50 @@
 	<meta charset="UTF-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>Soccer Game</title>
-	<style>
-		body {
-			margin: 0;
-			padding: 0;
-			overflow: hidden;
-			font-family: Arial, sans-serif;
-		}
+        <style>
+                body {
+                        margin: 0;
+                        padding: 0;
+                        overflow: hidden;
+                        font-family: Arial, sans-serif;
+                }
 
 		#game-container {
 			width: 100vw;
 			height: 100vh;
 		}
 
-		#controls {
-			position: absolute;
-			top: 10px;
-			left: 10px;
-			color: white;
-			background: rgba(0, 0, 0, 0.5);
-			padding: 10px;
-			border-radius: 5px;
-		}
-	</style>
+                #controls {
+                        position: absolute;
+                        top: 10px;
+                        left: 10px;
+                        color: white;
+                        background: rgba(0, 0, 0, 0.5);
+                        padding: 10px;
+                        border-radius: 5px;
+                }
+
+                #time-display {
+                        position: absolute;
+                        top: 10px;
+                        right: 10px;
+                        color: white;
+                        background: rgba(0, 0, 0, 0.5);
+                        padding: 10px;
+                        border-radius: 5px;
+                        font-family: Arial, sans-serif;
+                }
+        </style>
 </head>
 
 <body>
-	<div id="game-container"></div>
-	<div id="controls">
-		<p>Arrow Keys: Move • Run into ball: Dribble • Space: Shoot • T: Switch Team</p>
-		<p style="font-size: 12px; margin-top: 5px;">🔊 Click or press any key to enable sound</p>
-	</div>
-	<script type="module" src="/game.js"></script>
+        <div id="game-container"></div>
+        <div id="controls">
+                <p>Arrow Keys: Move • Run into ball: Dribble • Space: Shoot • T: Switch Team</p>
+                <p style="font-size: 12px; margin-top: 5px;">🔊 Click or press any key to enable sound</p>
+        </div>
+        <div id="time-display"></div>
+        <script type="module" src="/game.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- display match time
- track halves with a 60 second timer
- start a penalty shootout when the score is tied after regulation

## Testing
- `npm run build-game`

------
https://chatgpt.com/codex/tasks/task_e_68740dda99d08331ae58344e19e3f382