### PR TITLE
Improve goalkeeper AI

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -2454,13 +2454,14 @@ class SoccerGame {
         if (keeper.holdTime! > 1) {
           keeper.hasBall = false;
           this.rollBallToTeammate(keeper);
+          this.dribblingPlayer = null;
         }
       } else {
         const dist = keeper.mesh.position.distanceTo(this.ball.position);
         if (dist < 1.5 && this.ball.position.y < 2) {
           keeper.hasBall = true;
           keeper.holdTime = 0;
-          this.dribblingPlayer = null;
+          this.dribblingPlayer = keeper;
           this.isDribbling = false;
         }
       }
@@ -3176,7 +3177,13 @@ class SoccerGame {
     let closestDist = Infinity;
 
     this.players.forEach((player) => {
-      if (player === keeper || player.team !== keeper.team || player.redCard) return;
+      if (
+        player === keeper ||
+        player.team !== keeper.team ||
+        player.redCard ||
+        player.position === Position.GK
+      )
+        return;
 
       const dist = player.mesh.position.distanceTo(keeper.mesh.position);
       if (dist < 30 && dist < closestDist) {


### PR DESCRIPTION
## Summary
- allow goalkeepers to move, dive and catch the ball
- treat keepers as players and update formations
- add updateGoalkeepers routine and track keeper state

## Testing
- `npm run build-game`

------
https://chatgpt.com/codex/tasks/task_e_68740fe3eeec83318f01411527bf74d1