### PR TITLE
Add settings popover

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,14 +18,28 @@
 			height: 100vh;
 		}
 
-                #controls {
+                #settings-button {
                         position: absolute;
                         top: 10px;
+                        left: 10px;
+                        background: rgba(0, 0, 0, 0.5);
+                        color: white;
+                        border: none;
+                        padding: 6px;
+                        border-radius: 5px;
+                        cursor: pointer;
+                        z-index: 1001;
+                }
+
+                #controls {
+                        position: absolute;
+                        top: 50px;
                         left: 10px;
                         color: white;
                         background: rgba(0, 0, 0, 0.5);
                         padding: 10px;
                         border-radius: 5px;
+                        display: none;
                 }
 
                 #pause-button {
@@ -49,6 +63,7 @@
 
 <body>
         <div id="game-container"></div>
+        <button id="settings-button">⚙️</button>
         <div id="controls">
                 <p>Arrow Keys: Move • Run into ball: Dribble • Space: Shoot • T: Switch Team</p>
                 <p style="font-size: 12px; margin-top: 5px;">🔊 Click or press any key to enable sound</p>
@@ -56,6 +71,17 @@
         </div>
         <div id="time-display"></div>
         <script type="module" src="/game.js"></script>
+        <script>
+                const settingsButton = document.getElementById('settings-button');
+                const controls = document.getElementById('controls');
+                settingsButton.addEventListener('click', () => {
+                        if (controls.style.display === 'none' || controls.style.display === '') {
+                                controls.style.display = 'block';
+                        } else {
+                                controls.style.display = 'none';
+                        }
+                });
+        </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- hide control text and sound enable prompt in a Settings popover
- add settings button and toggle logic

## Testing
- `npm run build-game`

------
https://chatgpt.com/codex/tasks/task_e_68741685242883318b92e8f2c5be5f9e