### PR TITLE
Hide mobile controls until difficulty selected

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -144,6 +144,7 @@ class SoccerGame {
 
   // UI elements
   private menuContainer: HTMLDivElement | null = null;
+  private touchControlsContainer: HTMLDivElement | null = null;
 
   // Movement state
   private keys = {
@@ -390,6 +391,9 @@ class SoccerGame {
 
     // Show game canvas
     this.renderer.domElement.style.opacity = "1";
+    if (this.touchControlsContainer) {
+      this.touchControlsContainer.style.display = "block";
+    }
 
     // Create teams
     this.createTeams();
@@ -1708,7 +1712,9 @@ class SoccerGame {
     controlsContainer.style.height = "auto";
     controlsContainer.style.pointerEvents = "none";
     controlsContainer.style.zIndex = "1000";
+    controlsContainer.style.display = "none"; // Hidden until difficulty is selected
     document.body.appendChild(controlsContainer);
+    this.touchControlsContainer = controlsContainer;
 
     // Create d-pad container
     const dpadContainer = document.createElement("div");


### PR DESCRIPTION
## Summary
- manage a mobile touch control container
- hide mobile controls by default until the user chooses a difficulty

## Testing
- `npm run build-game`


------
https://chatgpt.com/codex/tasks/task_e_68741c20d4088331a12d1d293b2475f5