### PR TITLE
Disable text selection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,10 +13,23 @@
                         font-family: Arial, sans-serif;
                 }
 
-		#game-container {
-			width: 100vw;
-			height: 100vh;
-		}
+                /* Prevent accidental text selection on mobile */
+                body,
+                * {
+                        -webkit-user-select: none;
+                        -moz-user-select: none;
+                        -ms-user-select: none;
+                        user-select: none;
+                }
+
+                #game-container {
+                        width: 100vw;
+                        height: 100vh;
+                        -webkit-user-select: none;
+                        -moz-user-select: none;
+                        -ms-user-select: none;
+                        user-select: none;
+                }
 
                 #settings-button {
                         position: absolute;


### PR DESCRIPTION
## Summary
- make canvas and UI text unselectable so mobile gameplay isn't interrupted

## Testing
- `npm run build-game`

------
https://chatgpt.com/codex/tasks/task_e_687424a3615c83319577cd91e9657b0c