### PR TITLE
Add basic World Cup mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Yo! Welcome to our awesome 3D soccer game where you can live out your Sporting C
 - Camera angle giving you those FIFA game vibes
 - Score a goal and watch the whole place go nuts
 - Confetti! Because GOALS = PARTY 🎉
+- Challenge yourself in the new **World Cup mode** and lift the trophy
 
 ### Sounds of the Game
 


### PR DESCRIPTION
## Summary
- add a minimal World Cup tournament option
- show next round button after each win
- celebrate with trophy podium and fire effects on victory
- document the new mode in README

## Testing
- `npm run build-game`

------
https://chatgpt.com/codex/tasks/task_e_6876e94f6fe883319ab175ea49969919