### PR TITLE
Reset scores when matches or teams change

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -521,6 +521,11 @@ class SoccerGame {
     // Create referees
     this.createReferees();
 
+    // Reset scores for a new match
+    this.scores.home = 0;
+    this.scores.away = 0;
+    this.updateCornerDisplay();
+
 
     // Reset match timing
     this.currentHalf = 1;
@@ -2923,6 +2928,11 @@ class SoccerGame {
       this.humanPlayer.mesh.position.copy(currentPos);
       this.humanPlayer.mesh.rotation.copy(currentRot);
       this.humanPlayer.team = this.currentTeam;
+
+      // Reset score when switching teams mid-match
+      this.scores.home = 0;
+      this.scores.away = 0;
+      this.updateCornerDisplay();
     }
 
     // Update ball physics


### PR DESCRIPTION
## Summary
- reset scores on match start
- reset scores when manually switching teams mid-game

## Testing
- `npm run build-game`

------
https://chatgpt.com/codex/tasks/task_e_6876ed6413788331bdf530e09b342ae3