### PR TITLE
Add international team selection in World Cup mode

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -532,7 +532,17 @@ class SoccerGame {
     wcButton.addEventListener("click", () => {
       const host = prompt("World Cup host country?", "Qatar");
       if (!host) return;
-      this.homeTeamName = homeSelect.value;
+
+      // Determine a sensible default team
+      const defaultTeam = international.includes(homeSelect.value)
+        ? homeSelect.value
+        : "Portugal";
+      const team = prompt(
+        "Choose your national team",
+        defaultTeam
+      );
+      if (!team || !international.includes(team)) return;
+      this.homeTeamName = team;
       this.startWorldCup(host);
     });
     this.menuContainer!.appendChild(wcButton);


### PR DESCRIPTION
## Summary
- ask for the World Cup team after selecting the host
- limit the team choices to international squads

## Testing
- `npm run build-game`

------
https://chatgpt.com/codex/tasks/task_e_6876f3aeb298833198eb92c8581b687d