### PR TITLE
Add World Cup 2022 kits

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -8,3 +8,4 @@ export * from './primeira_liga';
 export * from './belgian_pro';
 export * from './mls';
 export * from './international';
+export * from './world_cup_2022_kits';

--- a/src/data/team_kits.ts
+++ b/src/data/team_kits.ts
@@ -1,3 +1,4 @@
+import { worldCup2022Kits } from "./world_cup_2022_kits";
 export interface FieldKit {
   shirtColors: number[];
   shortsColor: number;
@@ -10,7 +11,7 @@ export interface TeamKit {
   goalkeeper: FieldKit;
 }
 
-export const teamKits: Record<string, TeamKit> = {
+const baseTeamKits: Record<string, TeamKit> = {
   "Cercle Brugge": {
     "field": {
       "shirtColors": [
@@ -3846,3 +3847,5 @@ export const teamKits: Record<string, TeamKit> = {
     }
   }
 };
+
+export const teamKits: Record<string, TeamKit> = { ...baseTeamKits, ...worldCup2022Kits };

--- a/src/data/world_cup_2022_kits.ts
+++ b/src/data/world_cup_2022_kits.ts
@@ -1,0 +1,452 @@
+import { TeamKit } from './team_kits';
+
+export const worldCup2022Kits: Record<string, TeamKit> = {
+  "Qatar": {
+    field: {
+      shirtColors: [0x8a1538],
+      shortsColor: 0x8a1538,
+      sockPrimaryColor: 0x8a1538,
+      sockSecondaryColor: 0xffffff,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Ecuador": {
+    field: {
+      shirtColors: [0xfedf00],
+      shortsColor: 0x002664,
+      sockPrimaryColor: 0xfedf00,
+      sockSecondaryColor: 0xfedf00,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Senegal": {
+    field: {
+      shirtColors: [0xffffff],
+      shortsColor: 0x009e49,
+      sockPrimaryColor: 0xffffff,
+      sockSecondaryColor: 0xff0000,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Netherlands": {
+    field: {
+      shirtColors: [0xff6600],
+      shortsColor: 0xff6600,
+      sockPrimaryColor: 0xff6600,
+      sockSecondaryColor: 0xff6600,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "England": {
+    field: {
+      shirtColors: [0xffffff],
+      shortsColor: 0x002654,
+      sockPrimaryColor: 0xffffff,
+      sockSecondaryColor: 0xffffff,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Iran": {
+    field: {
+      shirtColors: [0xffffff],
+      shortsColor: 0xff0000,
+      sockPrimaryColor: 0xffffff,
+      sockSecondaryColor: 0x00a55a,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "United States": {
+    field: {
+      shirtColors: [0xffffff],
+      shortsColor: 0x002654,
+      sockPrimaryColor: 0xffffff,
+      sockSecondaryColor: 0xb22234,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Wales": {
+    field: {
+      shirtColors: [0xd3131c],
+      shortsColor: 0xffffff,
+      sockPrimaryColor: 0xd3131c,
+      sockSecondaryColor: 0xd3131c,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Argentina": {
+    field: {
+      shirtColors: [0x75aadb],
+      shortsColor: 0xffffff,
+      sockPrimaryColor: 0xffffff,
+      sockSecondaryColor: 0x75aadb,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Saudi Arabia": {
+    field: {
+      shirtColors: [0xffffff],
+      shortsColor: 0xffffff,
+      sockPrimaryColor: 0xffffff,
+      sockSecondaryColor: 0x006c35,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Mexico": {
+    field: {
+      shirtColors: [0x006847],
+      shortsColor: 0xffffff,
+      sockPrimaryColor: 0xff0000,
+      sockSecondaryColor: 0x006847,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Poland": {
+    field: {
+      shirtColors: [0xffffff],
+      shortsColor: 0xdb261d,
+      sockPrimaryColor: 0xffffff,
+      sockSecondaryColor: 0xdb261d,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "France": {
+    field: {
+      shirtColors: [0x002654],
+      shortsColor: 0x002654,
+      sockPrimaryColor: 0xc60c30,
+      sockSecondaryColor: 0xc60c30,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Australia": {
+    field: {
+      shirtColors: [0xffcc00],
+      shortsColor: 0x006a44,
+      sockPrimaryColor: 0xffcc00,
+      sockSecondaryColor: 0xffcc00,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Denmark": {
+    field: {
+      shirtColors: [0xc60c30],
+      shortsColor: 0xc60c30,
+      sockPrimaryColor: 0xc60c30,
+      sockSecondaryColor: 0xffffff,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Tunisia": {
+    field: {
+      shirtColors: [0xffffff],
+      shortsColor: 0xff0000,
+      sockPrimaryColor: 0xffffff,
+      sockSecondaryColor: 0xff0000,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Spain": {
+    field: {
+      shirtColors: [0xaa151b],
+      shortsColor: 0x00008b,
+      sockPrimaryColor: 0xaa151b,
+      sockSecondaryColor: 0xaa151b,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Costa Rica": {
+    field: {
+      shirtColors: [0xce1126],
+      shortsColor: 0x0b4ea2,
+      sockPrimaryColor: 0xce1126,
+      sockSecondaryColor: 0xffffff,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Germany": {
+    field: {
+      shirtColors: [0xffffff],
+      shortsColor: 0x000000,
+      sockPrimaryColor: 0xffffff,
+      sockSecondaryColor: 0x000000,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Japan": {
+    field: {
+      shirtColors: [0x2a3b9d],
+      shortsColor: 0xffffff,
+      sockPrimaryColor: 0x2a3b9d,
+      sockSecondaryColor: 0x2a3b9d,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Belgium": {
+    field: {
+      shirtColors: [0xef3340],
+      shortsColor: 0x000000,
+      sockPrimaryColor: 0xef3340,
+      sockSecondaryColor: 0xef3340,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Canada": {
+    field: {
+      shirtColors: [0xff0000],
+      shortsColor: 0xff0000,
+      sockPrimaryColor: 0xff0000,
+      sockSecondaryColor: 0xffffff,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Morocco": {
+    field: {
+      shirtColors: [0xff0000],
+      shortsColor: 0x006233,
+      sockPrimaryColor: 0xff0000,
+      sockSecondaryColor: 0xff0000,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Croatia": {
+    field: {
+      shirtColors: [0xff0000],
+      shortsColor: 0xffffff,
+      sockPrimaryColor: 0xffffff,
+      sockSecondaryColor: 0xff0000,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Brazil": {
+    field: {
+      shirtColors: [0xffcc00],
+      shortsColor: 0x002776,
+      sockPrimaryColor: 0xffffff,
+      sockSecondaryColor: 0xffcc00,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Serbia": {
+    field: {
+      shirtColors: [0xdb1223],
+      shortsColor: 0x0041a4,
+      sockPrimaryColor: 0xffffff,
+      sockSecondaryColor: 0xdb1223,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Switzerland": {
+    field: {
+      shirtColors: [0xff0000],
+      shortsColor: 0xff0000,
+      sockPrimaryColor: 0xff0000,
+      sockSecondaryColor: 0xffffff,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Cameroon": {
+    field: {
+      shirtColors: [0x007a5e],
+      shortsColor: 0xce1126,
+      sockPrimaryColor: 0xffd600,
+      sockSecondaryColor: 0x007a5e,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Portugal": {
+    field: {
+      shirtColors: [0xc0003f],
+      shortsColor: 0x006600,
+      sockPrimaryColor: 0xc0003f,
+      sockSecondaryColor: 0xc0003f,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Ghana": {
+    field: {
+      shirtColors: [0xffffff],
+      shortsColor: 0x000000,
+      sockPrimaryColor: 0xffffff,
+      sockSecondaryColor: 0x000000,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "Uruguay": {
+    field: {
+      shirtColors: [0x5cbfeb],
+      shortsColor: 0x000000,
+      sockPrimaryColor: 0x5cbfeb,
+      sockSecondaryColor: 0x000000,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+  "South Korea": {
+    field: {
+      shirtColors: [0xfa243c],
+      shortsColor: 0x000000,
+      sockPrimaryColor: 0xfa243c,
+      sockSecondaryColor: 0xfa243c,
+    },
+    goalkeeper: {
+      shirtColors: [0xffff00],
+      shortsColor: 0xffff00,
+      sockPrimaryColor: 0xffff00,
+      sockSecondaryColor: 0x000000,
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- introduce `worldCup2022Kits` dataset with colors for each national team
- merge these kits into `teamKits`
- export dataset via `src/data/index.ts`

## Testing
- `npm run build-game`

------
https://chatgpt.com/codex/tasks/task_e_6877aec3fc8883319e19550083112875