### PR TITLE
Restrict World Cup to national teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Yo! Welcome to our awesome 3D soccer game where you can live out your Sporting C
 - Score a goal and watch the whole place go nuts
 - Confetti! Because GOALS = PARTY 🎉
 - Challenge yourself in the new **World Cup mode** and lift the trophy
+  - Select your favorite international squad from the team menu – clubs aren't allowed!
 
 ### Sounds of the Game
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -530,19 +530,14 @@ class SoccerGame {
       wcButton.style.transform = "scale(1)";
     });
     wcButton.addEventListener("click", () => {
+      if (!international.includes(homeSelect.value)) {
+        alert("Please choose an international team from the dropdown first.");
+        return;
+      }
       const host = prompt("World Cup host country?", "Qatar");
       if (!host) return;
 
-      // Determine a sensible default team
-      const defaultTeam = international.includes(homeSelect.value)
-        ? homeSelect.value
-        : "Portugal";
-      const team = prompt(
-        "Choose your national team",
-        defaultTeam
-      );
-      if (!team || !international.includes(team)) return;
-      this.homeTeamName = team;
+      this.homeTeamName = homeSelect.value;
       this.startWorldCup(host);
     });
     this.menuContainer!.appendChild(wcButton);


### PR DESCRIPTION
## Summary
- ensure World Cup mode requires picking an international team
- document in the README that clubs cannot participate

## Testing
- `npm run build-game`

------
https://chatgpt.com/codex/tasks/task_e_6877b0614aa883319d4644c667acfe56